### PR TITLE
at least be able to decode stream with multiple IDRs

### DIFF
--- a/app/xevd_app.c
+++ b/app/xevd_app.c
@@ -480,7 +480,7 @@ int main(int argc, const char **argv)
 
                     nal_unit_type = ( ( bs_buf[ 0 ] >> 1 ) & 0x3f ) - 1;
 
-                    if( nal_unit_type == 1 )
+                    if( nal_unit_type == XEVD_NUT_IDR )
                     {
                         if( has_idr_slice == 1 )
                         {

--- a/app/xevd_app_args.h
+++ b/app/xevd_app_args.h
@@ -327,6 +327,7 @@ static int  op_out_chroma_format = 1;
 typedef enum _STATES
 {
     STATE_DECODING,
+    STATE_BUMPING_IDR,
     STATE_BUMPING
 } STATES;
 

--- a/src_base/xevd_picman.c
+++ b/src_base/xevd_picman.c
@@ -112,11 +112,26 @@ static void pic_marking_no_rpl(XEVD_PM * pm, int ref_pic_gap_length)
 static void picman_flush_pb(XEVD_PM * pm)
 {
     int i;
+    XEVD_PIC *pic;
 
     /* mark all frames unused */
-    for(i = 0; i < MAX_PB_SIZE; i++)
+    while( pm->cur_num_ref_pics > 0 )
     {
-        if(pm->pic[i]) SET_REF_UNMARK(pm->pic[i]);
+        for( i = 0; i < MAX_PB_SIZE; i++ )
+        {
+            if( pm->pic[ i ] && IS_REF( pm->pic[ i ] ) )
+            {
+                pic = pm->pic[ i ];
+
+                /* unmark for reference */
+                SET_REF_UNMARK( pic );
+                picman_move_pic( pm, i, MAX_PB_SIZE - 1 );
+
+                pm->cur_num_ref_pics--;
+
+                break;
+            }
+        }
     }
     pm->cur_num_ref_pics = 0;
 }

--- a/src_main/xevdm_picman.c
+++ b/src_main/xevdm_picman.c
@@ -119,11 +119,26 @@ static void pic_marking_no_rpl(XEVDM_PM * pm, int ref_pic_gap_length)
 static void picman_flush_pb(XEVDM_PM * pm)
 {
     int i;
+    XEVD_PIC *pic;
 
     /* mark all frames unused */
-    for(i = 0; i < MAXM_PB_SIZE; i++)
+    while( pm->cur_num_ref_pics > 0 )
     {
-        if(pm->pic[i]) SET_REF_UNMARK(pm->pic[i]);
+        for( i = 0; i < MAX_PB_SIZE; i++ )
+        {
+            if( pm->pic[ i ] && IS_REF( pm->pic[ i ] ) )
+            {
+                pic = pm->pic[ i ];
+
+                /* unmark for reference */
+                SET_REF_UNMARK( pic );
+                picman_move_pic( pm, i, MAX_PB_SIZE - 1 );
+
+                pm->cur_num_ref_pics--;
+
+                break;
+            }
+        }
     }
     pm->cur_num_ref_pics = 0;
 }


### PR DESCRIPTION
Your current handling of IDRs and multiple SPS is somewhat off I think.

I tried to change your code so that on the app layer it looks ahead in the bitstream and does a flush when a new IDR is encountered. I had to change the picture buffer flush in picman for IDR pictures as it did not do everything needed to free reference picture. Another approach would be to do a complete teardown and reinit on IDR but that would be quite some speed hit, it would fix certain other issues though.

The decoder then crashes on the 17th SPS  encountered in the stream because there is no ctx->sps_id bounds checking. Might I suggest you reconsider your architecture regarding context and sequence, storing sequence contexts with for example PPS, picture buffer etc, below some sequence structure which is bound to some SPS ID ? Or something like that ?

In case you need a sample stream with multiple ( identical )SPS and IDRs and some closed GOPs of different sizes I uploaded a baseline profile sample here which I think should be correct:
[Some Google Drive Folder](https://drive.google.com/drive/folders/1plFE_-kqDrWs_rqYaHMkVWqxgQyCvQvo?usp=sharing)

Thanks.
