### PR TITLE
Changes following alterations in XEVE library related to reordering b…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,15 @@ project (XEVD VERSION 1.0.0)
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 # Set compiler flags and options.
+
+message("Processor byte order: ${CMAKE_C_BYTE_ORDER}")
+
+if( ${CMAKE_C_BYTE_ORDER} STREQUAL "LITTLE_ENDIAN")
+  set(CMAKE_C_FLAGS ${CMAKE_C_FLAGS} -DLITTLE_ENDIAN_BYTE_ORDER)
+else()
+  set(CMAKE_C_FLAGS ${CMAKE_C_FLAGS} -DBIG_ENDIAN_BYTE_ORDER)
+endif()
+
 if( MSVC )
 elseif( UNIX OR MINGW )
     if(NOT CMAKE_BUILD_TYPE)

--- a/app/xevd_app.c
+++ b/app/xevd_app.c
@@ -69,7 +69,7 @@ static int read_bitstream(FILE * fp, int * pos, unsigned char * bs_buf)
         if(XEVD_NAL_UNIT_LENGTH_BYTE == fread(&bs_size, 1, XEVD_NAL_UNIT_LENGTH_BYTE, fp))
         {
             // Reorder the bytes of a 32-bit unsigned value from network order to processor order
-            bs_size = ntohl(bs_size); 
+            bs_size = XEVD_BIG_ENDIAN_LONG(bs_size); 
             if(bs_size <= 0)
             {
                 logv0("Invalid bitstream size![%d]\n", bs_size);

--- a/app/xevd_app.c
+++ b/app/xevd_app.c
@@ -33,6 +33,12 @@
 #include "xevd_app_util.h"
 #include "xevd_app_args.h"
 
+#if (defined(_WIN64) || defined(_WIN32)) && !defined(__GNUC__)
+#include <winsock.h>
+#else
+#include <arpa/inet.h>
+#endif
+
 #define MAX_BS_BUF                 16*1024*1024 /* byte */
 
 static void print_usage(void)
@@ -62,6 +68,8 @@ static int read_bitstream(FILE * fp, int * pos, unsigned char * bs_buf)
         /* read size first */
         if(XEVD_NAL_UNIT_LENGTH_BYTE == fread(&bs_size, 1, XEVD_NAL_UNIT_LENGTH_BYTE, fp))
         {
+            // Reorder the bytes of a 32-bit unsigned value from network order to processor order
+            bs_size = ntohl(bs_size); 
             if(bs_size <= 0)
             {
                 logv0("Invalid bitstream size![%d]\n", bs_size);

--- a/app/xevd_app.c
+++ b/app/xevd_app.c
@@ -68,8 +68,8 @@ static int read_bitstream(FILE * fp, int * pos, unsigned char * bs_buf)
         /* read size first */
         if(XEVD_NAL_UNIT_LENGTH_BYTE == fread(&bs_size, 1, XEVD_NAL_UNIT_LENGTH_BYTE, fp))
         {
-            // Reorder the bytes of a 32-bit unsigned value from network order to processor order
-            bs_size = XEVD_BIG_ENDIAN_LONG(bs_size); 
+            // Reorder the bytes of a 32-bit unsigned value from Big-endian to processor byte order
+            bs_size = XEVD_BE_TO_HOST_LONG(bs_size); 
             if(bs_size <= 0)
             {
                 logv0("Invalid bitstream size![%d]\n", bs_size);

--- a/inc/xevd.h
+++ b/inc/xevd.h
@@ -55,21 +55,24 @@ extern "C"
   (((data) <<  8) & 0x000000FF00000000) | (((data) << 24) & 0x0000FF0000000000) | \
   (((data) << 40) & 0x00FF000000000000) | (((data) << 56) & 0xFF00000000000000) ) )
 
-
 #ifdef LITTLE_ENDIAN_BYTE_ORDER
-#    define XEVD_LITTLE_ENDIAN_SHORT(n) (n)
-#    define XEVD_LITTLE_ENDIAN_LONG(n) (n)
-#    define XEVD_LITTLE_ENDIAN_LONG_LONG(n) (n)
-#    define XEVD_BIG_ENDIAN_SHORT(n) XEVD_REVERSE_BYTE_ORDER_SHORT(n)
-#    define XEVD_BIG_ENDIAN_LONG(n) XEVD_REVERSE_BYTE_ORDER_LONG(n)
-#    define XEVD_BIG_ENDIAN_LONG_LONG(n) XEVD_REVERSE_BYTE_ORDER_LONG_LONG(n)
+/* Convert 16, 32, 64-bits data from Litle-endian to Host byte order */
+#    define XEVD_LE_TO_HOST_SHORT(n) (n)
+#    define XEVD_LE_TO_HOST_LONG(n) (n)
+#    define XEVD_LE_TO_HOST_LONG_LONG(n) (n)
+/* Convert 16, 32, 64-bits data from Big-endian to Host byte order */
+#    define XEVD_BE_TO_HOST_SHORT(n) XEVD_REVERSE_BYTE_ORDER_SHORT(n)
+#    define XEVD_BE_TO_HOST_LONG(n) XEVD_REVERSE_BYTE_ORDER_LONG(n)
+#    define XEVD_BE_TO_HOST_LONG_LONG(n) XEVD_REVERSE_BYTE_ORDER_LONG_LONG(n)
 #else
-#    define XEVD_LITTLE_ENDIAN_SHORT(n) XEVD_REVERSE_BYTE_ORDER_SHORT(n)
-#    define XEVD_LITTLE_ENDIAN_LONG(n) XEVD_REVERSE_BYTE_ORDER_LONG(n)
-#    define XEVD_LITTLE_ENDIAN_LONG_LONG(n) XEVD_REVERSE_BYTE_ORDER_LONG(n)
-#    define XEVD_BIG_ENDIAN_SHORT(n) (n)
-#    define XEVD_BIG_ENDIAN_LONG(n) (n)
-#    define XEVD_BIG_ENDIAN_LONG_LONG(n) (n)
+/* Convert 16, 32, 64-bits data from Little-endian to Host byte order */
+#    define XEVD_LE_TO_HOST_SHORT(n) XEVD_REVERSE_BYTE_ORDER_SHORT(n)
+#    define XEVD_LE_TO_HOST_LONG(n) XEVD_REVERSE_BYTE_ORDER_LONG(n)
+#    define XEVD_LE_TO_HOST_LONG_LONG(n) XEVD_REVERSE_BYTE_ORDER_LONG(n)
+/* Convert 16, 32, 64-bits data from Big-endian to Host byte order */
+#    define XEVD_BE_TO_HOST_SHORT(n) (n)
+#    define XEVD_BE_TO_HOST_LONG(n) (n)
+#    define XEVD_BE_TO_HOST_LONG_LONG(n) (n)
 #endif
 
 /* xevd decoder const */

--- a/inc/xevd.h
+++ b/inc/xevd.h
@@ -40,6 +40,38 @@ extern "C"
 #include <stdint.h>
 #include <xevd_exports.h>
 
+#define is_bigendian() (!*(unsigned char *)&(uint16_t){1})
+
+#define XEVD_REVERSE_BYTE_ORDER_SHORT(data) ((unsigned short) \
+( (((data) >> 8) & 0x00FF) | (((data) << 8) & 0xFF00) )  )
+
+#define XEVD_REVERSE_BYTE_ORDER_LONG(data) ((unsigned long)  \
+( (((data) >> 24) & 0x000000FF) | (((data) >>  8) & 0x0000FF00) | \
+  (((data) <<  8) & 0x00FF0000) | (((data) << 24) & 0xFF000000) ) )
+
+#define XEVD_REVERSE_BYTE_ORDER_LONG_LONG(data) ((unsigned long long)  \
+( (((data) >> 56) & 0x00000000000000FF) | (((data) >> 40) & 0x000000000000FF00) | \
+  (((data) >> 24) & 0x0000000000FF0000) | (((data) >>  8) & 0x00000000FF000000) | \
+  (((data) <<  8) & 0x000000FF00000000) | (((data) << 24) & 0x0000FF0000000000) | \
+  (((data) << 40) & 0x00FF000000000000) | (((data) << 56) & 0xFF00000000000000) ) )
+
+
+#ifdef LITTLE_ENDIAN_BYTE_ORDER
+#    define XEVD_LITTLE_ENDIAN_SHORT(n) (n)
+#    define XEVD_LITTLE_ENDIAN_LONG(n) (n)
+#    define XEVD_LITTLE_ENDIAN_LONG_LONG(n) (n)
+#    define XEVD_BIG_ENDIAN_SHORT(n) XEVD_REVERSE_BYTE_ORDER_SHORT(n)
+#    define XEVD_BIG_ENDIAN_LONG(n) XEVD_REVERSE_BYTE_ORDER_LONG(n)
+#    define XEVD_BIG_ENDIAN_LONG_LONG(n) XEVD_REVERSE_BYTE_ORDER_LONG_LONG(n)
+#else
+#    define XEVD_LITTLE_ENDIAN_SHORT(n) XEVD_REVERSE_BYTE_ORDER_SHORT(n)
+#    define XEVD_LITTLE_ENDIAN_LONG(n) XEVD_REVERSE_BYTE_ORDER_LONG(n)
+#    define XEVD_LITTLE_ENDIAN_LONG_LONG(n) XEVD_REVERSE_BYTE_ORDER_LONG(n)
+#    define XEVD_BIG_ENDIAN_SHORT(n) (n)
+#    define XEVD_BIG_ENDIAN_LONG(n) (n)
+#    define XEVD_BIG_ENDIAN_LONG_LONG(n) (n)
+#endif
+
 /* xevd decoder const */
 #define XEVD_MAX_TASK_CNT                  8
 


### PR DESCRIPTION
…ytes of 32-bit NAL unit size prefixes

Bytes of a 32-bit NAL unit prefixes storing NAL unit sizes has been reordered from processor byte order to network byte order