### PR TITLE
fixed nal_unit_length parsing

### DIFF
--- a/inc/xevd.h
+++ b/inc/xevd.h
@@ -287,7 +287,7 @@ typedef struct _XEVD_STAT
 {
     /* byte size of decoded bitstream (read size of bitstream) */
     int            read;
-    /* nalu type */
+    /* nal unit type */
     int            nalu_type;
     /* slice type */
     int            stype;
@@ -304,6 +304,20 @@ typedef struct _XEVD_STAT
     /* list of reference pictures */
     int            refpic[2][16];
 } XEVD_STAT;
+
+
+/*****************************************************************************
+ * brief information of bitstream
+ *****************************************************************************/
+typedef struct _XEVD_INFO
+{
+    /* nal unit length (available for Annex-B format) */
+    int            nalu_len;
+    /* nal unit type */
+    int            nalu_type;
+    /* nal unit temporal id */
+    int            nalu_tid;
+} XEVD_INFO;
 
 typedef struct _XEVD_OPL
 {
@@ -327,6 +341,7 @@ void XEVD_EXPORT xevd_delete(XEVD id);
 int  XEVD_EXPORT xevd_decode(XEVD id, XEVD_BITB * bitb, XEVD_STAT * stat);
 int  XEVD_EXPORT xevd_pull(XEVD id, XEVD_IMGB ** img, XEVD_OPL * opl);
 int  XEVD_EXPORT xevd_config(XEVD id, int cfg, void * buf, int * size);
+int  XEVD_EXPORT xevd_info(void * bits, int bits_size, int is_annexb, XEVD_INFO * info);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/src_base/xevd.c
+++ b/src_base/xevd.c
@@ -295,16 +295,16 @@ static int slice_init(XEVD_CTX * ctx, XEVD_CORE * core, XEVD_SH * sh)
     return XEVD_OK;
 }
 
-static void make_stat(XEVD_CTX * ctx, int btype, XEVD_STAT * stat)
+static void make_stat(XEVD_CTX * ctx, int nalu_type, XEVD_STAT * stat)
 {
     int i, j;
-    stat->nalu_type = btype;
+    stat->nalu_type = nalu_type;
     stat->stype = 0;
     stat->fnum = -1;
     if(ctx)
     {
         stat->read += XEVD_BSR_GET_READ_BYTE(&ctx->bs);
-        if(btype < XEVD_NUT_SPS)
+        if(nalu_type < XEVD_NUT_SPS)
         {
             stat->fnum = ctx->pic_cnt;
             stat->stype = ctx->sh.slice_type;
@@ -1120,7 +1120,7 @@ int xevd_deblock(void * arg)
                 core->x_lcu++;
             }
             core->y_lcu = core->y_lcu + ctx->tc.task_num_in_tile[0];
-            core->x_lcu = 0;           
+            core->x_lcu = 0;
         }
     }
     return XEVD_OK;
@@ -1393,11 +1393,11 @@ int xevd_ctu_row_rec_mt(void * arg)
         xevd_threadsafe_assign(&ctx->sync_flag[core->lcu_num], THREAD_TERMINATED);
         xevd_threadsafe_decrement(ctx->sync_block, (volatile s32 *)&ctx->tile[0].f_ctb);
 
-        if (ctx->tc.task_num_in_tile[0] > 2) 
+        if (ctx->tc.task_num_in_tile[0] > 2)
         {
             core->lcu_num = mt_get_next_ctu_num(ctx, core, ctx->tc.task_num_in_tile[0] - 1);
         }
-        else 
+        else
         {
         core->lcu_num = mt_get_next_ctu_num(ctx, core, ctx->tc.task_num_in_tile[0]);
         }
@@ -1418,7 +1418,7 @@ int xevd_tile_mt(void * arg)
     int          res, ret = XEVD_OK;
     int          thread_idx = core->thread_idx + ctx->tc.tile_task_num;
     xevd_mset((void *)ctx->sync_row, 0, ctx->tile[0].h_ctb * sizeof(ctx->sync_row[0]));
-    if (ctx->tc.task_num_in_tile[0] > 2) 
+    if (ctx->tc.task_num_in_tile[0] > 2)
     {
         for (int thread_cnt = 1; thread_cnt < ctx->tc.task_num_in_tile[0]; thread_cnt++)
         {
@@ -1449,7 +1449,7 @@ int xevd_tile_mt(void * arg)
             thread_idx += ctx->tc.tile_task_num;
         }
     }
-    else 
+    else
     {
 
     ret = xevd_tile_eco(arg);

--- a/src_main/xevdm.c
+++ b/src_main/xevdm.c
@@ -442,16 +442,16 @@ static int xevdm_hmvp_init(XEVD_CORE * core)
     return core->history_buffer.currCnt;
 }
 
-static void make_stat(XEVD_CTX * ctx, int btype, XEVD_STAT * stat)
+static void make_stat(XEVD_CTX * ctx, int nalu_type, XEVD_STAT * stat)
 {
     int i, j;
-    stat->nalu_type = btype;
+    stat->nalu_type = nalu_type;
     stat->stype = 0;
     stat->fnum = -1;
     if(ctx)
     {
         stat->read += XEVD_BSR_GET_READ_BYTE(&ctx->bs);
-        if(btype < XEVD_NUT_SPS)
+        if(nalu_type < XEVD_NUT_SPS)
         {
             stat->fnum = ctx->pic_cnt;
             stat->stype = ctx->sh.slice_type;
@@ -1128,7 +1128,7 @@ static int xevd_recon_unit(XEVD_CTX * ctx, XEVD_CORE * core, int x, int y, int l
 
     xevdm_get_ctx_some_flags(core->x_scu, core->y_scu, cuw, cuh, ctx->w_scu, ctx->map_scu, ctx->cod_eco, ctx->map_cu_mode, core->ctx_flags, ctx->sh.slice_type, ctx->sps->tool_cm_init
                          , ctx->sps->ibc_flag, ctx->sps->ibc_log_max_size, ctx->map_tidx, 0);
-    
+
     /* inverse transform and dequantization */
     if(core->pred_mode != MODE_SKIP)
     {
@@ -1317,7 +1317,7 @@ static int xevd_entropy_dec_unit(XEVD_CTX * ctx, XEVD_CORE * core, int x, int y,
 
     xevdm_get_ctx_some_flags(core->x_scu, core->y_scu, cuw, cuh, ctx->w_scu, ctx->map_scu, ctx->cod_eco, ctx->map_cu_mode, core->ctx_flags, ctx->sh.slice_type, ctx->sps->tool_cm_init
                          , ctx->sps->ibc_flag, ctx->sps->ibc_log_max_size, ctx->map_tidx, 1);
-    
+
     /* parse CU info */
     ret = xevdm_eco_cu(ctx, core);
     xevd_assert_g(ret == XEVD_OK, ERR);
@@ -1672,7 +1672,7 @@ static int xevd_entropy_decode_tree(XEVD_CTX * ctx, XEVD_CORE * core, int x0, in
 
                     xevdm_get_ctx_some_flags(core->x_scu, core->y_scu, cuw, cuh, ctx->w_scu, ctx->map_scu, ctx->cod_eco, ctx->map_cu_mode, core->ctx_flags, ctx->sh.slice_type, ctx->sps->tool_cm_init
                                          , ctx->sps->ibc_flag, ctx->sps->ibc_log_max_size, ctx->map_tidx, 1);
-                  
+
                     mode_cons_for_child = xevdm_eco_mode_constr(core->bs, core->ctx_flags[CNID_MODE_CONS]);
                 }
             }
@@ -2359,7 +2359,7 @@ int xevd_ctu_row_rec_mt(void * arg)
     //LCU decoding with in a tile
     while (ctx->tile[tile_idx].f_ctb > 0)
     {
-        if (ctx->num_tiles_in_slice == 1 && ctx->tc.max_task_cnt > 2) 
+        if (ctx->num_tiles_in_slice == 1 && ctx->tc.max_task_cnt > 2)
         {
             xevd_spinlock_wait(&ctx->sync_row[core->y_lcu], THREAD_TERMINATED);
         }


### PR DESCRIPTION
The previous parsing scheme of "nal_unit_length" was not correct.
It should be u(32) syntax.
According to standard the parsing scheme has changed to support u(32).
