### PR TITLE
valid right nbr access modification, max_coding_delay and fps support…

### DIFF
--- a/src_base/xevd_def.h
+++ b/src_base/xevd_def.h
@@ -1435,6 +1435,9 @@ struct _XEVD_CTX
     SYNC_OBJ                sync_block; //has to be initialized at context creation and has to be released on context destruction
     /* mximum number of coding delay */
     s32                     max_coding_delay;
+    /* Frame rate */
+	s32                     frame_rate_num;
+	s32                     frame_rate_den;
     /* address of ready function */
     int  (* fn_ready)(XEVD_CTX * ctx);
     /* address of flush function */

--- a/src_main/xevdm_ipred.c
+++ b/src_main/xevdm_ipred.c
@@ -126,7 +126,8 @@ void xevdm_get_nbr(int x, int y, int cuw, int cuh, pel *src, int s_src, u16 avai
 
     for (i = 0; i < (scuh + scuw); i++)
     {
-        int is_avail = (x_scu < w_scu) && (y_scu + i < h_scu);
+        /*Check if right neighbours are available */
+        int is_avail = (x_scu + scuw + i < w_scu) && (y_scu + i < h_scu);
         if (is_avail && MCU_GET_COD(map_scu[scup + scuw + i * w_scu]) && (!constrained_intra_pred || MCU_GET_IF(map_scu[scup + scuw + i * w_scu])) &&
             (map_tidx[scup] == map_tidx[scup + scuw + i * w_scu]))
         {


### PR DESCRIPTION
Made modification to support compliance for inputs with unaligned resolution, and to cover the boundary conditions for available right neighbour access in intra prediction.
Added multi tile configuration fix and  support to acccess fps and sps_max_dec_pic_buffering_minus1 from the encoded bitstream.