### PR TITLE
Add GitHub Actions workflow for preparing packages

### DIFF
--- a/.github/workflows/prepare_packages.yml
+++ b/.github/workflows/prepare_packages.yml
@@ -1,0 +1,36 @@
+name: Prepare packages
+on:
+  release:
+    types: [published]
+
+  workflow_dispatch:
+
+jobs:
+
+  package-xevd-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: install dependencies
+        run: |
+          sudo apt-get update -qq && sudo apt-get -y install \
+          build-essential \
+          cmake
+        
+      - name: build xevd, generate packages and md5
+        run: |
+          mkdir build
+          cd build
+          cmake .. -DBUILD_TYPE=Release
+          make
+          make package
+        
+      - name: 'Upload xevd artifacts'
+        uses: actions/upload-artifact@v3
+        with:
+          name: xevd-packages-${{ github.event.release.tag_name }}
+          path: |
+            ${{ github.workspace }}/build/*.deb
+            ${{ github.workspace }}/build/*.md5
+          retention-days: 7


### PR DESCRIPTION
This commit implements GitHub action that is able to create deb packages for Linux build.
On each release it generate standard and development packages and also md5 sums for that packages.