### PR TITLE
Fix cross compilation of Windows on Linux

### DIFF
--- a/src_base/xevd_tp.c
+++ b/src_base/xevd_tp.c
@@ -32,7 +32,7 @@
 #include <stdlib.h>
 #include "xevd_tp.h"
 #if defined(WIN32) || defined(WIN64)
-#include <Windows.h>
+#include <windows.h>
 #include <process.h>
 #else
 #include <pthread.h>


### PR DESCRIPTION
This will solve the problem by changing from Windows.h to windows.h for smallcase first letter.