### PR TITLE
src_{base,main}: Drop typedef redefinition for C99 compatibility

### DIFF
--- a/src_base/xevd_tbl.h
+++ b/src_base/xevd_tbl.h
@@ -61,9 +61,9 @@ extern int * xevd_qp_chroma_dynamic[2];
 void xevd_derived_chroma_qp_mapping_tables(XEVD_CHROMA_TABLE *struct_chroma_qp, int bit_depth);
 void xevd_set_chroma_qp_tbl_loc(int codec_bit_depth);
 
-typedef struct _XEVD_SCAN_TABLES {
+struct _XEVD_SCAN_TABLES {
     u16* xevd_inv_scan_tbl[COEF_SCAN_TYPE_NUM][MAX_CU_LOG2 - 1][MAX_CU_LOG2 - 1];
     u16* xevd_scan_tbl[COEF_SCAN_TYPE_NUM][MAX_CU_LOG2 - 1][MAX_CU_LOG2 - 1];
-} XEVD_SCAN_TABLES;
+};
 
 #endif /* _XEVD_TBL_H_ */

--- a/src_main/xevdm_alf.h
+++ b/src_main/xevdm_alf.h
@@ -301,7 +301,7 @@ static const u8 tb_max[257] = { 0, 0, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 
 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 8 };
 
-typedef struct _ALF_FILTER_SHAPE
+struct _ALF_FILTER_SHAPE
 {
     int filter_type;
     int filterLength;
@@ -312,7 +312,7 @@ typedef struct _ALF_FILTER_SHAPE
     int golombIdx[14];
     int pattern_to_large_filter[13];
 
-} ALF_FILTER_SHAPE;
+};
 
 struct _ALF_SLICE_PARAM
 {

--- a/src_main/xevdm_dra.h
+++ b/src_main/xevdm_dra.h
@@ -71,7 +71,7 @@ typedef struct _DRA_SCALE_MAPPING
     double dra_scale_map_y[256][2];          ///< first=luma level, second=delta QP.
 } DRA_SCALE_MAPPING;
 
-typedef struct _SIG_PARAM_DRA
+struct _SIG_PARAM_DRA
 {
     int  signal_dra_flag; // flag has 3 positions at encoder: -1: not initialized, 0: initialized and sent, 1: initialized, to be sent
     int  dra_table_idx;
@@ -84,7 +84,7 @@ typedef struct _SIG_PARAM_DRA
     int  dra_cb_scale_value;
     int  dra_cr_scale_value;
     int  dra_scale_value[33 - 1];
-}SIG_PARAM_DRA;
+};
 
 typedef struct _DRA_CONTROL
 {

--- a/src_main/xevdm_itdq.c
+++ b/src_main/xevdm_itdq.c
@@ -65,8 +65,6 @@ void xevdm_itrans_ats_intra_DCT8_B32(s16 *coeff, s16 *block, int shift, int line
 
 
 
-typedef void INV_TRANS(s16 *, s16 *, int, int, int, int);
-
 INV_TRANS *xevdm_itrans_map_tbl[16][5] =
 {
     { NULL, xevdm_itrans_ats_intra_DCT8_B4, xevdm_itrans_ats_intra_DCT8_B8, xevdm_itrans_ats_intra_DCT8_B16, xevdm_itrans_ats_intra_DCT8_B32 },


### PR DESCRIPTION
Dropped the typedef from struct declarations in `xevd_tbl.h`, `xevdm_alf.h` and `xevdm_dra.h`.

Dropped the repeated typedef of `INV_TRANS` in `xevdm_itdq.c`.

Opted to drop the typedefs from the struct declarations rather than dropping the forward declarations. But could change that around.

This is a parallel PR to mpeg5/xeve#125, splitting up #63.