### PR TITLE
xevdm_util: Avoid skipping cnt_tmp values

### DIFF
--- a/src_main/xevdm_util.c
+++ b/src_main/xevdm_util.c
@@ -2755,7 +2755,6 @@ void xevdm_get_affine_motion_scaling(int poc, int scup, int lidx, s8 cur_refi, i
             mvp[cnt_tmp][1][MV_Y] = 0;
             mvp[cnt_tmp][2][MV_X] = 0;
             mvp[cnt_tmp][2][MV_Y] = 0;
-            cnt_tmp++;
         }
     }
 }


### PR DESCRIPTION
This fixes a potential bug where a loop in `xevem_util.c` is iterating over an array with a step size of 2.

This is a parallel PR to mpeg5/xeve#126, split out of #63.