### PR TITLE
pkgconfig: Use CMAKE_INSTALL_FULL_*

### DIFF
--- a/pkgconfig/xevd.pc.in
+++ b/pkgconfig/xevd.pc.in
@@ -1,8 +1,8 @@
 # --- xevd.pc.in file ---
 prefix=@CMAKE_INSTALL_PREFIX@
-exec_prefix=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_BINDIR@
-libdir=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@
-includedir=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_INCLUDEDIR@/@LIB_NAME@
+exec_prefix=@CMAKE_INSTALL_FULL_BINDIR@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@/@LIB_NAME@
 
 Name: xevd
 Description: eXtra-fast Essential Video Decoder (XEVD) (MAIN profile)

--- a/pkgconfig/xevdb.pc.in
+++ b/pkgconfig/xevdb.pc.in
@@ -1,8 +1,8 @@
 # --- xevdb.pc.in file ---
 prefix=@CMAKE_INSTALL_PREFIX@
-exec_prefix=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_BINDIR@
-libdir=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@
-includedir=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_INCLUDEDIR@/@LIB_NAME_BASE@
+exec_prefix=@CMAKE_INSTALL_FULL_BINDIR@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@/@LIB_NAME_BASE@
 
 Name: xevdb
 Description: eXtra-fast Essential Video Decoder (XEVD) (BASE profile)


### PR DESCRIPTION
Rather than manually prefixing CMAKE_INSTALL_PREFIX, use the CMAKE_INSTALL_FULL_* variants. This prevents ending up with a non-existent path when the CMAKE_INSTALL_* paths are already absolute.

This is a parallel PR to mpeg5/xeve#127, split out of #63.