### PR TITLE
xevd_dbk_neon: Fix header guard

### DIFF
--- a/src_base/neon/xevd_dbk_neon.h
+++ b/src_base/neon/xevd_dbk_neon.h
@@ -28,7 +28,7 @@
    POSSIBILITY OF SUCH DAMAGE.
 */
 
-#ifndef _XEVD_DBK_NOEN_H_
+#ifndef _XEVD_DBK_NEON_H_
 #define _XEVD_DBK_NEON_H_
 
 


### PR DESCRIPTION
`_XEVD_DBK_NOEN_H_` is used as a header guard but is followed by a define of `_XEVD_DBK_NEON_H_`.

Split out of #63 because that was requested for the Neon-touching commit in the xeve PR as well. Unlike that PR messing with types this one seems like a genuine typo bug though so it might be useful.