### PR TITLE
src_main: Add libm link for xevd_dynamic

### DIFF
--- a/src_main/CMakeLists.txt
+++ b/src_main/CMakeLists.txt
@@ -107,6 +107,7 @@ elseif( UNIX OR MINGW )
     endif()
 
     set_target_properties(${LIB_NAME}_dynamic PROPERTIES FOLDER lib LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+    target_link_libraries(${LIB_NAME}_dynamic m)
     target_compile_definitions( ${LIB_NAME} PUBLIC ANY LINUX )
     target_link_libraries(${LIB_NAME} m)
 endif()


### PR DESCRIPTION
We run into the following error when building ffmpeg with xevd support unless we explicitly pass `-lm` in CFLAGS:

```
ERROR: xevd >= 0.4.1 not found using pkg-config

If you think configure made a mistake, make sure you are using the latest
version from Git.  If the latest version fails, report the problem to the
ffmpeg-user@ffmpeg.org mailing list or IRC #ffmpeg on irc.libera.chat.
Include the log file "ffbuild/config.log" produced by configure as this will help
solve the problem.
```

With help I've tracked this down to `src_main/CMakeLists.txt` specifying `target_link_libraries(${LIB_NAME} m)` only for the static library target and not the shared library.

By specifying the dependency for the shared library too the resulting `libxevd.so` contains a proper reference to a `libm.so`, which means downstream doesn't need to provide `-lm`.