### PR TITLE
Allow building on non-x86 systems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,18 @@ endif()
 message ("c Flags: " ${CMAKE_C_FLAGS})
 message ("linker Flags: " ${CMAKE_EXE_LINKER_FLAGS})
 
+# To build for arm provide in command line: -DARM=TRUE
+if(NOT ARM)
+  set(ARM "FALSE")
+else()
+  add_definitions(-DARM=1)
+  set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -flax-vector-conversions")
+  if(NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
+    set(CMAKE_EXE_LINKER_FLAGS "-static")
+  endif()
+endif()
+message("ARM=${ARM}")
+
 ########################################
 # Configuration
 ########################################

--- a/src_base/CMakeLists.txt
+++ b/src_base/CMakeLists.txt
@@ -15,14 +15,26 @@ file (GLOB LIB_NEON_INC "neon/xevd_*.h" )
 
 include(GenerateExportHeader)
 include_directories("${CMAKE_BINARY_DIR}")
+
+set(ARM "FALSE")
+message("SYSTEM_PROCESSOR=${CMAKE_SYSTEM_PROCESSOR}")
+if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "^(arm|aarch)")
+  set(ARM "TRUE")
+elseif(${CMAKE_SYSTEM_PROCESSOR} MATCHES "^(x86|ia64|i386|i686)")
+  set(X86 "TRUE")
+endif()
+
 if("${ARM}" STREQUAL "TRUE")
     add_library( ${LIB_NAME_BASE} STATIC ${LIB_API_SRC} ${XEVD_INC} ${LIB_BASE_SRC} ${LIB_BASE_INC} ${LIB_NEON_SRC} ${LIB_NEON_INC} )
     add_library( ${LIB_NAME_BASE}_dynamic SHARED ${LIB_API_SRC} ${XEVD_INC} ${LIB_BASE_SRC} ${LIB_BASE_INC} ${LIB_NEON_SRC} ${LIB_NEON_INC} )
-else()
+elseif(X86)
     add_library( ${LIB_NAME_BASE} STATIC ${LIB_API_SRC} ${XEVD_INC} ${LIB_BASE_SRC} ${LIB_BASE_INC} ${LIB_SSE_SRC} ${LIB_SSE_INC}
                                        ${LIB_AVX_SRC} ${LIB_AVX_INC} )
     add_library( ${LIB_NAME_BASE}_dynamic SHARED ${LIB_API_SRC} ${XEVD_INC} ${LIB_BASE_SRC} ${LIB_BASE_INC} ${LIB_SSE_SRC} ${LIB_SSE_INC}
                                                ${LIB_AVX_SRC} ${LIB_AVX_INC} )
+else()
+    add_library( ${LIB_NAME_BASE} STATIC ${LIB_API_SRC} ${XEVD_INC} ${LIB_BASE_SRC} ${LIB_BASE_INC} )
+    add_library( ${LIB_NAME_BASE}_dynamic SHARED ${LIB_API_SRC} ${XEVD_INC} ${LIB_BASE_SRC} ${LIB_BASE_INC} )
 endif()
 
 set_target_properties(${LIB_NAME_BASE}_dynamic PROPERTIES VERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR} SOVERSION ${LIB_SOVERSION})
@@ -56,8 +68,10 @@ source_group("base\\neon\\source" FILES ${LIB_NEON_SRC})
 
 if("${ARM}" STREQUAL "TRUE")
     include_directories( ${LIB_NAME_BASE} PUBLIC . .. ../inc ./neon)
-else()
+elseif(X86)
     include_directories( ${LIB_NAME_BASE} PUBLIC . .. ../inc ./sse ./avx)
+else()
+    include_directories( ${LIB_NAME_BASE} PUBLIC . .. ../inc)
 endif()
 
 
@@ -86,7 +100,11 @@ if( MSVC )
                             ARCHIVE_OUTPUT_DIRECTORY  ${CMAKE_CURRENT_BINARY_DIR}/import/lib)
 elseif( UNIX OR MINGW )
 
-    if("${ARM}" STREQUAL "FALSE")
+    if(ARM)
+        add_definitions(-DARM=1)
+        set_property( SOURCE ${NEON} APPEND PROPERTY COMPILE_FLAGS "-flax-vector-conversions")
+    elseif(X86)
+        add_definitions(-DX86=1)
         set_property( SOURCE ${SSE} APPEND PROPERTY COMPILE_FLAGS "-msse4.1" )
         set_property( SOURCE ${AVX} APPEND PROPERTY COMPILE_FLAGS " -mavx2" )
     endif()

--- a/src_base/xevd_def.h
+++ b/src_base/xevd_def.h
@@ -1498,7 +1498,7 @@ int  xevd_dec_slice(XEVD_CTX * ctx, XEVD_CORE * core);
 #include "xevd_mc.h"
 #include "xevd_eco.h"
 #include "xevd_df.h"
-#ifndef ARM
+#if defined(X86)
 #include "xevd_mc_sse.h"
 #include "xevd_mc_avx.h"
 #include "xevd_itdq_sse.h"
@@ -1506,7 +1506,7 @@ int  xevd_dec_slice(XEVD_CTX * ctx, XEVD_CORE * core);
 #include "xevd_recon_avx.h"
 #include "xevd_recon_sse.h"
 #include "xevd_dbk_sse.h"
-#else
+#elif defined(ARM)
 #include "xevd_mc_neon.h"
 #include "xevd_itdq_neon.h"
 #include "xevd_recon_neon.h"

--- a/src_base/xevd_port.h
+++ b/src_base/xevd_port.h
@@ -137,10 +137,10 @@ void xevd_trace_line(char * pre);
 #define xevd_assert_gv(x,r,v,g) \
     {if(!(x)){assert(x); (r)=(v); goto g;}}
 
-#ifndef ARM
+#if defined(X86)
 #define X86_SSE                 1
 #define ARM_NEON                0
-#else
+#elif defined(ARM)
 #define X86_SSE                 0
 #define ARM_NEON                1
 #endif

--- a/src_main/CMakeLists.txt
+++ b/src_main/CMakeLists.txt
@@ -27,16 +27,27 @@ file (GLOB LIB_MAIN_NEON_INC "./neon/xevdm_*.h" )
 include(GenerateExportHeader)
 include_directories("${CMAKE_BINARY_DIR}")
 
+set(ARM "FALSE")
+message("SYSTEM_PROCESSOR=${CMAKE_SYSTEM_PROCESSOR}")
+if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "^(arm|aarch)")
+  set(ARM "TRUE")
+elseif(${CMAKE_SYSTEM_PROCESSOR} MATCHES "^(x86|ia64|i386|i686)")
+  set(X86 "TRUE")
+endif()
+
 if("${ARM}" STREQUAL "TRUE")
     add_library( ${LIB_NAME} STATIC ${LIB_API_MAIN_SRC} ${XEVD_INC} ${LIB_BASE_SRC} ${LIB_BASE_INC} ${LIB_MAIN_SRC} ${LIB_MAIN_INC} 
                                     ${LIB_NEON_SRC} ${LIB_NEON_INC} ${LIB_MAIN_NEON_SRC} ${LIB_MAIN_NEON_INC} )
     add_library( ${LIB_NAME}_dynamic SHARED ${LIB_API_MAIN_SRC} ${XEVD_INC} ${LIB_BASE_SRC} ${LIB_BASE_INC} ${LIB_MAIN_SRC} ${LIB_MAIN_INC} 
                                     ${LIB_NEON_SRC} ${LIB_NEON_INC} ${LIB_MAIN_NEON_SRC} ${LIB_MAIN_NEON_INC} )
-else()
+elseif(X86)
     add_library( ${LIB_NAME} STATIC ${LIB_API_MAIN_SRC} ${XEVD_INC} ${LIB_BASE_SRC} ${LIB_BASE_INC} ${LIB_MAIN_SRC} ${LIB_MAIN_INC}
                                     ${LIB_SSE_SRC} ${LIB_SSE_INC} ${LIB_MAIN_SSE_SRC} ${LIB_MAIN_SSE_INC} ${LIB_AVX_SRC} ${LIB_AVX_INC} ${LIB_MAIN_AVX_SRC} ${LIB_MAIN_AVX_INC} )
     add_library( ${LIB_NAME}_dynamic SHARED ${LIB_API_MAIN_SRC} ${XEVD_INC} ${LIB_BASE_SRC} ${LIB_BASE_INC} ${LIB_MAIN_SRC} ${LIB_MAIN_INC}
                                             ${LIB_SSE_SRC} ${LIB_SSE_INC} ${LIB_MAIN_SSE_SRC} ${LIB_MAIN_SSE_INC} ${LIB_AVX_SRC} ${LIB_AVX_INC} ${LIB_MAIN_AVX_SRC} ${LIB_MAIN_AVX_INC} )
+else()
+    add_library( ${LIB_NAME} STATIC ${LIB_API_MAIN_SRC} ${XEVD_INC} ${LIB_BASE_SRC} ${LIB_BASE_INC} ${LIB_MAIN_SRC} ${LIB_MAIN_INC} )
+    add_library( ${LIB_NAME}_dynamic SHARED ${LIB_API_MAIN_SRC} ${XEVD_INC} ${LIB_BASE_SRC} ${LIB_BASE_INC} ${LIB_MAIN_SRC} ${LIB_MAIN_INC} )
 endif()
 
 set_target_properties(${LIB_NAME}_dynamic PROPERTIES VERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR} SOVERSION ${LIB_SOVERSION})
@@ -79,12 +90,15 @@ source_group("main\\neon\\source" FILES ${LIB_MAIN_NEON_SRC})
 
 if("${ARM}" STREQUAL "TRUE")
     include_directories( ${LIB_NAME} PUBLIC . .. ../inc ./neon ../src_base ../src_base/neon)
-else()
+elseif(X86)
     include_directories( ${LIB_NAME} PUBLIC . .. ../inc ./sse ./avx ../src_base ../src_base/sse ../src_base/avx)
+else()
+    include_directories( ${LIB_NAME} PUBLIC . .. ../inc ../src_base)
 endif()
 
 set( SSE ${BASE_INC_FILES} ${LIB_SSE_SRC} ${LIB_MAIN_SSE_SRC})
 set( AVX ${LIB_AVX_SRC} ${LIB_MAIN_AVX_SRC})
+set( NEON ${LIB_NEON_SRC} ${LIB_MAIN_NEON_SRC})
 
 set_target_properties(${LIB_NAME}_dynamic PROPERTIES OUTPUT_NAME ${LIB_NAME})
 
@@ -101,7 +115,11 @@ if( MSVC )
     set_target_properties(${LIB_NAME}_dynamic PROPERTIES FOLDER lib
                             ARCHIVE_OUTPUT_DIRECTORY  ${CMAKE_CURRENT_BINARY_DIR}/import/lib)
 elseif( UNIX OR MINGW )
-    if("${ARM}" STREQUAL "FALSE")
+    if(ARM)
+        add_definitions(-DARM=1)
+        set_property( SOURCE ${NEON} APPEND PROPERTY COMPILE_FLAGS "-flax-vector-conversions")
+    elseif(X86)
+        add_definitions(-DX86=1)
         set_property( SOURCE ${SSE} APPEND PROPERTY COMPILE_FLAGS "-msse4.1" )
         set_property( SOURCE ${AVX} APPEND PROPERTY COMPILE_FLAGS " -mavx2" )
     endif()


### PR DESCRIPTION
Checking if there is any interest for this... This patch allows to build for ARM systems without the need for a cross compilation on an x86_64 system.

The changes allow the software to build like a native package on an `aarch64` system, pretty much like the `x86_64` one.

Linux distributions shipping `xevd` patch the software in a similar way to have a "normal" package that builds from source.

If there is any interest, I can update the various docs on the topic.