### PR TITLE
Add contributing guidelines to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,5 +154,14 @@ XEVD supports main and baseline profiles of EVC.
 ### Example
 	xevd_app -i input_bitstream.evc -o output_video.yuv
 
+## How to contribute
+Contributions are welcome through GitHub pull requests.
+
+* Fork the repository and create a topic branch from `master`.
+* Keep each PR focused; put unrelated fixes into separate PRs.
+* Make sure both profiles still build before submitting (`-DSET_PROF=MAIN` and `-DSET_PROF=BASE`).
+* Sign off your commits (`git commit -s`).
+* **Please enable "Allow edits from maintainers" when opening a pull request.** This lets maintainers push small fixes (build tweaks, rebases, style cleanups) directly to your branch instead of going through another round of review comments, which can significantly shorten the review cycle.
+
 ## License
 See [COPYING](COPYING) file for details.


### PR DESCRIPTION
Adds a short "How to contribute" section near the end of the README: topic branches, focused PRs, building both profiles, commit sign-off.

It also asks contributors to enable "Allow edits from maintainers" when opening a PR, so maintainers can push small fixes directly to the contributor's branch instead of another round of review comments. This should shorten the review cycle for cases like recent build-system PRs.
